### PR TITLE
Fix various issues

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 import os
 import optparse
 import subprocess

--- a/examples/simple/fbuildroot.py
+++ b/examples/simple/fbuildroot.py
@@ -60,7 +60,7 @@ def config_build(ctx, *, platform, cc, cxx):
     ctx.logger.log('configuring build phase', color='cyan')
 
     return Record(
-        platform=call('fbuild.builders.platform.platform', ctx, platform),
+        platform=call('fbuild.builders.platform.guess_platform', ctx, platform),
         c=make_c_builder(ctx, exe=cc),
         cxx=make_cxx_builder(ctx, exe=cxx),
     )
@@ -70,7 +70,7 @@ def config_host(ctx, build, *,
         platform, cc, cxx, ocamlc, ocamlopt, ocamllex, ocamlyacc):
     ctx.logger.log('configuring host phase', color='cyan')
 
-    platform = call('fbuild.builders.platform.platform', ctx, platform)
+    platform = call('fbuild.builders.platform.guess_platform', ctx, platform)
 
     if platform == build.platform:
         ctx.logger.log("using build's c and cxx compiler")
@@ -94,7 +94,7 @@ def config_host(ctx, build, *,
 def config_target(ctx, host, *, platform, cc, cxx):
     ctx.logger.log('configuring target phase', color='cyan')
 
-    platform = call('fbuild.builders.platform.platform', ctx, platform)
+    platform = call('fbuild.builders.platform.guess_platform', ctx, platform)
 
     if platform == host.platform:
         ctx.logger.log("using host's c and cxx compiler")

--- a/lib/fbuild/builders/ocaml/__init__.py
+++ b/lib/fbuild/builders/ocaml/__init__.py
@@ -694,7 +694,7 @@ class Ocamlcp(BytecodeBuilder):
         if profile_flags is None:
             profile_flags = self.profile_flags
 
-        return super()._run(*args, flags=flags + profile_flags, **kwargs)
+        return super()._run(*args, flags=tuple(flags) + profile_flags, **kwargs)
 
 # ------------------------------------------------------------------------------
 

--- a/lib/fbuild/subprocess/killableprocess.py
+++ b/lib/fbuild/subprocess/killableprocess.py
@@ -204,6 +204,9 @@ class Popen(subprocess.Popen):
         if self.returncode is not None:
             return self.returncode
 
+        if timeout is None:
+            timeout = -1
+
         if mswindows:
             if timeout != -1:
                 timeout = timeout * 1000

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 
 """Test cases for the fnmatch module."""
 

--- a/tests/test_functools.py
+++ b/tests/test_functools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 
 import unittest
 

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 
 import unittest
 from test.support import TESTFN

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.1
+#!/usr/bin/env python3
 
 import time
 import random


### PR DESCRIPTION
Fixes:

- Under Python 3.4, this happened whenever I did anything:

```
Traceback (most recent call last):
  File "../../fbuild-light", line 13, in <module>
    exec(compile(f.read(), fbuild_exename, 'exec'))
  File "../../bin/fbuild", line 159, in <module>
    sys.exit(main())
  File "../../bin/fbuild", line 135, in main
    result = build(ctx)
  File "../../bin/fbuild", line 82, in build
    target.function(ctx)
  File "/media/ryan/stuff/fb2/examples/c/fbuildroot.py", line 5, in build
    static = fbuild.builders.c.guess_static(ctx)
  File "../../lib/fbuild/builders/c/__init__.py", line 362, in guess_static
    ), *args, **kwargs)
  File "../../lib/fbuild/builders/c/__init__.py", line 325, in _guess_builder
    platform = fbuild.builders.platform.guess_platform(ctx, platform)
  File "../../lib/fbuild/db/__init__.py", line 121, in __call__
    result, srcs, dsts = self.call(*args, **kwargs)
  File "../../lib/fbuild/db/__init__.py", line 125, in call
    return ctx.db.call(self.function, ctx, *args, **kwargs)
  File "../../lib/fbuild/db/database.py", line 162, in call
    call_result = function(*args, **kwargs)
  File "../../lib/fbuild/builders/platform.py", line 72, in guess_platform
    stdout, stderr = ctx.execute((uname, '-s'), quieter=1)
  File "../../lib/fbuild/context.py", line 192, in execute
    stdout, stderr = p.communicate(input)
  File "/media/stuff/anaconda/lib/python3.4/subprocess.py", line 959, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/media/stuff/anaconda/lib/python3.4/subprocess.py", line 1645, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "../../lib/fbuild/subprocess/killableprocess.py", line 225, in wait
    while time.time() < starttime + timeout - 0.01:
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```

- Some of the examples didn't work

- Use python3 instead of python3.1 in the hashbang at the top of several files.