### PR TITLE
Rework the guess_* API

### DIFF
--- a/examples/c/fbuildroot.py
+++ b/examples/c/fbuildroot.py
@@ -3,29 +3,26 @@ import fbuild.builders.c
 import os
 
 def build(ctx):
-    # XXX: this is a tiny hack
-    # Basically, MinGW doesn't work. AppVeyor's Python wants us to use MinGW.
-    # So we override it.
-    plat = {'windows'} if 'APPVEYOR' in os.environ else None
-    static = fbuild.builders.c.guess_static(ctx, platform=plat)
-    lib1 = static.build_lib('static1', ['lib1/lib1.c'], macros=['STATIC_LINK'])
-    lib2 = static.build_lib('static2', ['lib2/lib2.c'], macros=['STATIC_LINK'],
+    builders = fbuild.builders.c.guess(ctx)
+
+    lib1 = builders.static.build_lib('static1', ['lib1/lib1.c'], macros=['STATIC_LINK'])
+    lib2 = builders.static.build_lib('static2', ['lib2/lib2.c'], macros=['STATIC_LINK'],
         includes=['lib1'], libs=[lib1])
 
     # If you specify the dependent libraries to build_lib, fbuild will
     # automatically add those libraries to the exe libraries.
-    exe = static.build_exe('static', ['exe.c'], macros=['STATIC_LINK'],
+    exe = builders.static.build_exe('static', ['exe.c'], macros=['STATIC_LINK'],
         includes=['lib1', 'lib2'], libs=[lib2])
 
     ctx.logger.log(' * running %s:' % exe)
-    static.run([exe])
+    builders.static.run([exe])
 
-    shared = fbuild.builders.c.guess_shared(ctx, platform=plat)
-    lib1 = shared.build_lib('shared1', ['lib1/lib1.c'], macros=['BUILD_LIB1'])
-    lib2 = shared.build_lib('shared2', ['lib2/lib2.c'], macros=['BUILD_LIB2'],
+    lib1 = builders.shared.build_lib('shared1', ['lib1/lib1.c'], macros=['BUILD_LIB1'])
+    lib2 = builders.shared.build_lib('shared2', ['lib2/lib2.c'], macros=['BUILD_LIB2'],
         includes=['lib1'], libs=[lib1])
-    exe = shared.build_exe('shared', [fbuild.path.Path.abspath('exe.c')], # test absolute paths
+    exe = builders.shared.build_exe('shared',
+        [fbuild.path.Path.abspath('exe.c')], # test absolute paths
         includes=['lib1', 'lib2'], libs=[lib2])
 
     ctx.logger.log(' * running %s:' % exe)
-    shared.run([exe])
+    builders.shared.run([exe])

--- a/examples/config/fbuildroot.py
+++ b/examples/config/fbuildroot.py
@@ -64,19 +64,15 @@ def test_module(ctx, builder, shared, module):
 def build(ctx):
     # C needs libm included for some math routines, but C++ links against libm
     # automatically.
-    c_static = fbuild.builders.c.guess_static(ctx, external_libs=['m'])
-    c_shared = fbuild.builders.c.guess_shared(ctx, external_libs=['m'])
-    cxx_static = fbuild.builders.cxx.guess_static(ctx, platform_options=[
-        ({'windows'}, {'flags': ['/EHsc']}),
-    ])
-    cxx_shared = fbuild.builders.cxx.guess_shared(ctx, platform_options=[
-        ({'windows'}, {'flags': ['/EHsc']}),
+    c = fbuild.builders.c.guess(ctx, external_libs=['m'])
+    cxx = fbuild.builders.cxx.guess(ctx, platform_options=[
+        ({'msvc++'}, {'flags': ['/EHsc']}),
     ])
     passed = 0
     total = 0
 
     # c tests
-    for builder in c_static, c_shared, cxx_static, cxx_shared:
+    for builder in c.static, c.shared, cxx.static, cxx.shared:
         for module in (
                 import_module('fbuild.config.c.bsd'),
                 import_module('fbuild.config.c.c90'),
@@ -100,19 +96,19 @@ def build(ctx):
                 import_module('fbuild.config.c.solaris'),
                 import_module('fbuild.config.c.stdlib'),
                 import_module('fbuild.config.c.win32')):
-            p, t = test_module(ctx, builder, c_shared, module)
+            p, t = test_module(ctx, builder, c.shared, module)
             passed += p
             total += t
 
     # c++ tests
-    for builder in cxx_static, cxx_shared:
+    for builder in cxx.static, cxx.shared:
         for module in (
                 import_module('fbuild.config.cxx.cmath'),
                 import_module('fbuild.config.cxx.cxx03'),
                 import_module('fbuild.config.cxx.gnu'),
                 import_module('fbuild.config.cxx.gtest'),
                 import_module('fbuild.config.cxx.iterator')):
-            p, t = test_module(ctx, builder, cxx_shared, module)
+            p, t = test_module(ctx, builder, cxx.shared, module)
             passed += p
             total += t
 

--- a/examples/cxx/fbuildroot.py
+++ b/examples/cxx/fbuildroot.py
@@ -1,23 +1,20 @@
 import fbuild.builders.cxx
 
 def build(ctx):
-    static = fbuild.builders.cxx.guess_static(ctx, platform_options=[
-        ({'windows'}, {'flags': ['/EHsc']}),
+    builders = fbuild.builders.cxx.guess(ctx, platform_options=[
+        ({'msvc++'}, {'flags': ['/EHsc']}),
         ({'posix'}, {'flags': ['-Wall', '-Werror']}),
     ])
-    lib = static.build_lib('lib_static', ['lib.cpp'], macros=['STATIC_LINK'])
-    exe = static.build_exe('exe_static', ['exe.cpp'], macros=['STATIC_LINK'],
+
+    lib = builders.static.build_lib('lib_static', ['lib.cpp'], macros=['STATIC_LINK'])
+    exe = builders.static.build_exe('exe_static', ['exe.cpp'], macros=['STATIC_LINK'],
         libs=[lib])
 
     ctx.logger.log(' * running %s:' % exe)
-    static.run([exe])
+    builders.static.run([exe])
 
-    shared = fbuild.builders.cxx.guess_shared(ctx, platform_options=[
-        ({'windows'}, {'flags': ['/EHsc']}),
-        ({'posix'}, {'flags': ['-Wall', '-Werror']}),
-    ])
-    lib = shared.build_lib('lib_shared', ['lib.cpp'], macros=['BUILD_LIB'])
-    exe = shared.build_exe('exe_shared', ['exe.cpp'], libs=[lib])
+    lib = builders.shared.build_lib('lib_shared', ['lib.cpp'], macros=['BUILD_LIB'])
+    exe = builders.shared.build_exe('exe_shared', ['exe.cpp'], libs=[lib])
 
     ctx.logger.log(' * running %s:' % exe)
-    shared.run([exe])
+    builders.shared.run([exe])

--- a/examples/install/fbuildroot.py
+++ b/examples/install/fbuildroot.py
@@ -1,7 +1,7 @@
-from fbuild.builders.c import guess_static
+from fbuild.builders.c import guess
 
 def build(ctx):
-    c = guess_static(ctx)
+    c = guess.static(ctx)
     exe = c.build_exe('x', ['x.c'])
     ctx.install(exe, 'bin')
     ctx.install('doc.txt', 'share', 'some_subdir_of_usr_share')

--- a/examples/simple/fbuildroot.py
+++ b/examples/simple/fbuildroot.py
@@ -31,29 +31,13 @@ def pre_options(parser):
 
 # -----------------------------------------------------------------------------
 
-def make_c_builder(*args, **kwargs):
-    static = call('fbuild.builders.c.guess_static', *args, **kwargs)
-    shared = call('fbuild.builders.c.guess_shared', *args, **kwargs)
+def make_c_builder(ctx, **kwargs):
+    return call('fbuild.builders.c.guess', ctx, **kwargs)
 
-    return Record(
-        static=static,
-        shared=shared)
-
-def make_cxx_builder(*args, **kwargs):
-    static = call('fbuild.builders.cxx.guess_static', *args,
-        platform_options=[
-            ({'windows'}, {'flags': ['/EHsc']}),
-        ],
-        **kwargs)
-    shared = call('fbuild.builders.cxx.guess_shared', *args,
-        platform_options=[
-            ({'windows'}, {'flags': ['/EHsc']}),
-        ],
-        **kwargs)
-
-    return Record(
-        static=static,
-        shared=shared)
+def make_cxx_builder(ctx, **kwargs):
+    return call('fbuild.builders.cxx.guess', ctx, platform_options=[
+            ({'windows'}, {'flags': ['/EHsc']})
+        ], **kwargs)
 
 @fbuild.db.caches
 def config_build(ctx, *, platform, cc, cxx):

--- a/lib/fbuild/builders/c/__init__.py
+++ b/lib/fbuild/builders/c/__init__.py
@@ -1,4 +1,4 @@
-import abc, copy
+import abc, copy, warnings, sys
 from functools import partial
 from itertools import chain
 
@@ -8,6 +8,7 @@ import fbuild.temp
 import fbuild.builders
 import fbuild.builders.platform
 import fbuild.functools
+import fbuild.record
 from fbuild.path import Path
 
 # ------------------------------------------------------------------------------
@@ -330,44 +331,6 @@ class Executable(Path):
 
 # ------------------------------------------------------------------------------
 
-def _guess_builder(name, compilers, functions, ctx, *args,
-        platform=None,
-        platform_options=[],
-        exe=None,
-        **kwargs):
-    if platform is None:
-        platform = fbuild.builders.platform.guess_platform(ctx, platform)
-
-    if exe is not None:
-        tp = identify_compiler(ctx, exe)
-        if tp is None:
-            raise fbuild.ConfigFailed('cannot identify exe given for %s' % name)
-        # Grab only the compiler type pertaining to this guess call.
-        platform |= tp & compilers
-    else:
-        # We're open to using all compilers.
-        platform |= compilers
-
-    for subplatform, function in functions:
-        if subplatform <= platform:
-            # Parse the platform options.
-            new_kwargs = copy.deepcopy(kwargs)
-
-            # Make sure that only the current compiler is passed to parse_platform_options.
-            simplified_platform = (platform - compilers) | subplatform
-            fbuild.builders.platform.parse_platform_options(ctx, simplified_platform,
-                platform_options, new_kwargs)
-
-            # Try to use this compiler. If it doesn't work, skip it and try another one.
-            try:
-                return fbuild.functools.call(function, ctx, exe, platform=platform,
-                                             *args, **new_kwargs)
-            except fbuild.ConfigFailed:
-                pass
-
-    raise fbuild.ConfigFailed('cannot find a %s builder for %s' % (name, platform))
-
-
 @fbuild.db.caches
 def identify_compiler(ctx, exe):
     res = None
@@ -385,8 +348,8 @@ def identify_compiler(ctx, exe):
         try:
             out, err = ctx.execute((exe, '--version'), quieter=1)
         except fbuild.ExecutionError:
+            # Is it MSVC?
             try:
-                # is it MSVC?
                 out, err = ctx.execute((exe,), quieter=1)
             except fbuild.ExecutionError:
                 pass
@@ -407,43 +370,121 @@ def identify_compiler(ctx, exe):
     return res
 
 
-def guess_static(*args, **kwargs):
-    """L{static} tries to guess the static system c compiler according to the
-    platform. It accepts a I{platform} keyword that overrides the system's
-    platform and a I{platform_extra} keyword that is joined to the system's
-    platform. This can be used to use a non-default compiler. Any extra
-    arguments and keywords are passed to the compiler's configuration
-    functions."""
+class Guesser:
+    def __init__(self, lang, compilers, functions):
+        self.lang = lang
+        self.compilers = compilers
+        self.functions = functions
 
-    return _guess_builder('c static', {'msvc', 'gcc', 'clang', 'icc'}, (
-        ({'windows', 'msvc'}, 'fbuild.builders.c.msvc.static'),
-        ({'avr', 'gcc'}, 'fbuild.builders.c.gcc.avr.static'),
+    def static(self, ctx, **kwargs):
+        return self(ctx, shared=None, **kwargs).static
+
+    def shared(self, ctx, **kwargs):
+        return self(ctx, static=None, **kwargs).shared
+
+    def __call__(self, ctx, static={}, shared={}, platform=None, platform_options={},
+                 exe=None, **kwargs):
+        """Try to find a set of builders. A static builder will be located using the
+        arguments in *static* combined with *kwargs*, and the shared builder will be
+        located using *shared* arguments combined with *kwargs*. Each
+        """
+        if platform is None:
+            platform = fbuild.builders.platform.guess_platform(ctx, platform)
+
+        if exe is not None:
+            tp = identify_compiler(ctx, exe)
+            if tp is None:
+                raise fbuild.ConfigFailed('cannot identify exe given for %s' % name)
+            # Grab only the compiler type pertaining to this guess call.
+            platform |= tp & self.compilers
+        else:
+            # We're open to using all compilers.
+            platform |= self.compilers
+
+        builders = {'static': static, 'shared': shared}
+
+        for subplatform, static_function, shared_function in self.functions:
+            if subplatform <= platform:
+                # We need to go through each requested builder and check the compiler.
+                result = fbuild.record.Record()
+                for builder, builder_args in builders.items():
+                    if builder_args is None:
+                        result[builder] = None
+                        continue
+
+                    if builder == 'static':
+                        function = static_function
+                    else:
+                        function = shared_function
+
+                    # Create a new arg dict, merging both kwargs and the builder-specific args.
+                    new_kwargs = copy.deepcopy(kwargs)
+                    new_kwargs.update(copy.deepcopy(builder_args))
+
+                    # Make sure that only the current compiler used for parsing
+                    # platform_options.
+                    simplified_platform = (platform - self.compilers) | subplatform
+                    # Now parse the options.
+                    fbuild.builders.platform.parse_platform_options(ctx,
+                        simplified_platform, platform_options, new_kwargs)
+
+                    # Try to use this compiler. If it doesn't work, then give up on this
+                    # subplatform and move on.
+                    try:
+                        result[builder] = fbuild.functools.call(function, ctx, exe,
+                                                                platform=platform,
+                                                                **new_kwargs)
+                    except fbuild.ConfigFailed:
+                        break
+
+                # If both builders are present in some form, then that means this
+                # function has succeeded. Time to return the result record.
+                if len(result) == 2:
+                    return result
+
+        # If we made it all the way here, then everything failed.
+        raise fbuild.ConfigFailed('cannot find a builder for %s' % platform)
+
+
+guess = Guesser('c', {'msvc', 'gcc', 'clang', 'icc'}, (
+        ({'windows', 'msvc'}, 'fbuild.builders.c.msvc.static',
+                              'fbuild.builders.c.msvc.shared'),
+        ({'avr', 'gcc'}, 'fbuild.builders.c.gcc.avr.static',
+                         'fbuild.builders.c.gcc.avr.shared'),
         ({'iphone', 'simulator', 'gcc'},
-            'fbuild.builders.c.gcc.iphone.static_simulator'),
-        ({'iphone', 'gcc'}, 'fbuild.builders.c.gcc.iphone.static'),
-        ({'darwin', 'clang'}, 'fbuild.builders.c.clang.darwin.static'),
-        ({'darwin', 'gcc'}, 'fbuild.builders.c.gcc.darwin.static'),
-        ({'clang'}, 'fbuild.builders.c.clang.static'),
-        ({'icc'}, 'fbuild.builders.c.intel.static'),
-        ({'gcc'}, 'fbuild.builders.c.gcc.static'),
-    ), *args, **kwargs)
-
-def guess_shared(*args, **kwargs):
-    """L{shared} tries to guess the shared system c compiler according to the
-    platform. It accepts a I{platform} keyword that overrides the system's
-    platform. This can be used to use a non-default compiler. Any extra
-    arguments and keywords are passed to the compiler's configuration
-    functions."""
-
-    return _guess_builder('c shared', {'msvc', 'gcc', 'clang', 'icc'}, (
-        ({'windows', 'msvc'}, 'fbuild.builders.c.msvc.shared'),
-        ({'avr', 'gcc'}, 'fbuild.builders.c.gcc.avr.shared'),
-        ({'iphone', 'simulator', 'gcc'},
+            'fbuild.builders.c.gcc.iphone.static_simulator',
             'fbuild.builders.c.gcc.iphone.shared_simulator'),
-        ({'iphone', 'gcc'}, 'fbuild.builders.c.gcc.iphone.shared'),
-        ({'darwin', 'clang'}, 'fbuild.builders.c.clang.darwin.shared'),
-        ({'darwin', 'gcc'}, 'fbuild.builders.c.gcc.darwin.shared'),
-        ({'clang'}, 'fbuild.builders.c.clang.shared'),
-        ({'icc'}, 'fbuild.builders.c.intel.static'),
-        ({'gcc'}, 'fbuild.builders.c.gcc.shared'),
-    ), *args, **kwargs)
+        ({'iphone', 'gcc'}, 'fbuild.builders.c.gcc.iphone.static',
+                            'fbuild.builders.c.gcc.iphone.shared'),
+        ({'darwin', 'clang'}, 'fbuild.builders.c.clang.darwin.static',
+                              'fbuild.builders.c.clang.darwin.shared'),
+        ({'darwin', 'gcc'}, 'fbuild.builders.c.gcc.darwin.static',
+                            'fbuild.builders.c.gcc.darwin.shared'),
+        ({'clang'}, 'fbuild.builders.c.clang.static',
+                    'fbuild.builders.c.clang.shared'),
+        ({'icc'}, 'fbuild.builders.c.intel.static',
+                  'fbuild.builders.c.intel.shared'),
+        ({'gcc'}, 'fbuild.builders.c.gcc.static',
+                  'fbuild.builders.gcc.shared'),
+    ))
+
+
+def _guess_deprecated(func):
+    def wrapper(*args, **kwargs):
+        warnings.warn('guess_static and guess_shared have been deprecated. Use ' \
+                      'guess.static(...) and guess.shared(...) instead.',
+                      DeprecationWarning, stacklevel=2)
+        # Prevent the warning from getting tangled up with in-progress checks.
+        sys.stdout.flush()
+        sys.stderr.flush()
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@_guess_deprecated
+def guess_static(ctx, **kwargs):
+    return guess.static(ctx, **kwargs)
+
+@_guess_deprecated
+def guess_shared(ctx, **kwargs):
+    return guess.shared(ctx, **kwargs)

--- a/lib/fbuild/builders/c/__init__.py
+++ b/lib/fbuild/builders/c/__init__.py
@@ -462,10 +462,10 @@ guess = Guesser('c', {'msvc', 'gcc', 'clang', 'icc'}, (
                             'fbuild.builders.c.gcc.darwin.shared'),
         ({'clang'}, 'fbuild.builders.c.clang.static',
                     'fbuild.builders.c.clang.shared'),
-        ({'icc'}, 'fbuild.builders.c.intel.static',
-                  'fbuild.builders.c.intel.shared'),
         ({'gcc'}, 'fbuild.builders.c.gcc.static',
                   'fbuild.builders.gcc.shared'),
+        ({'icc'}, 'fbuild.builders.c.intel.static',
+                  'fbuild.builders.c.intel.shared'),
     ))
 
 

--- a/lib/fbuild/builders/cxx/__init__.py
+++ b/lib/fbuild/builders/cxx/__init__.py
@@ -10,8 +10,8 @@ def guess_static(*args, **kwargs):
     functions."""
 
     return fbuild.builders.c._guess_builder('c++ static',
-        {'g++', 'clang++', 'icpc'}, (
-        ({'windows'}, 'fbuild.builders.cxx.msvc.static'),
+        {'msvc++', 'g++', 'clang++', 'icpc'}, (
+        ({'msvc++'}, 'fbuild.builders.cxx.msvc.static'),
         ({'iphone', 'simulator', 'g++'},
             'fbuild.builders.cxx.gxx.iphone.static_simulator'),
         ({'iphone', 'g++'}, 'fbuild.builders.cxx.gxx.iphone.static'),
@@ -30,8 +30,8 @@ def guess_shared(*args, **kwargs):
     functions."""
 
     return fbuild.builders.c._guess_builder('c++ shared',
-        {'g++', 'clang++', 'icpc'}, (
-        ({'windows'}, 'fbuild.builders.cxx.msvc.shared'),
+        {'msvc++', 'g++', 'clang++', 'icpc'}, (
+        ({'msvc++'}, 'fbuild.builders.cxx.msvc.shared'),
         ({'iphone', 'simulator'},
             'fbuild.builders.cxx.gxx.iphone.shared_simulator'),
         ({'iphone'}, 'fbuild.builders.cxx.gxx.iphone.shared'),

--- a/lib/fbuild/builders/cxx/__init__.py
+++ b/lib/fbuild/builders/cxx/__init__.py
@@ -17,10 +17,10 @@ guess = fbuild.builders.c.Guesser('c++', {'msvc++', 'g++', 'clang++', 'icpc'}, (
                             'fbuild.builders.cxx.gxx.darwin.shared'),
         ({'clang++'}, 'fbuild.builders.cxx.clangxx.static',
                       'fbuild.builders.cxx.clangxx.shared'),
-        ({'icpc'}, 'fbuild.builders.cxx.intelxx.static',
-                   'fbuild.builders.cxx.intelxx.shared'),
         ({'g++'}, 'fbuild.builders.cxx.gxx.static',
                   'fbuild.builders.cxx.gxx.static'),
+        ({'icpc'}, 'fbuild.builders.cxx.intelxx.static',
+                   'fbuild.builders.cxx.intelxx.shared'),
     ))
 
 

--- a/lib/fbuild/builders/cxx/__init__.py
+++ b/lib/fbuild/builders/cxx/__init__.py
@@ -2,42 +2,32 @@ import fbuild.builders.c
 
 # ------------------------------------------------------------------------------
 
-def guess_static(*args, **kwargs):
-    """L{static} tries to guess the static system c++ compiler according to the
-    platform. It accepts a I{platform} keyword that overrides the system's
-    platform. This can be used to use a non-default compiler. Any extra
-    arguments and keywords are passed to the compiler's configuration
-    functions."""
 
-    return fbuild.builders.c._guess_builder('c++ static',
-        {'msvc++', 'g++', 'clang++', 'icpc'}, (
-        ({'msvc++'}, 'fbuild.builders.cxx.msvc.static'),
+guess = fbuild.builders.c.Guesser('c++', {'msvc++', 'g++', 'clang++', 'icpc'}, (
+        ({'windows', 'msvc++'}, 'fbuild.builders.cxx.msvc.static',
+                     'fbuild.builders.cxx.msvc.shared'),
         ({'iphone', 'simulator', 'g++'},
-            'fbuild.builders.cxx.gxx.iphone.static_simulator'),
-        ({'iphone', 'g++'}, 'fbuild.builders.cxx.gxx.iphone.static'),
-        ({'darwin', 'clang++'}, 'fbuild.builders.cxx.clangxx.darwin.static'),
-        ({'darwin', 'g++'}, 'fbuild.builders.cxx.gxx.darwin.static'),
-        ({'clang++'}, 'fbuild.builders.cxx.clangxx.static'),
-        ({'icpc'}, 'fbuild.builders.cxx.intelxx.static'),
-        ({'g++'}, 'fbuild.builders.cxx.gxx.static'),
-    ), *args, **kwargs)
-
-def guess_shared(*args, **kwargs):
-    """L{shared} tries to guess the shared system c++ compiler according to the
-    platform. It accepts a I{platform} keyword that overrides the system's
-    platform. This can be used to use a non-default compiler. Any extra
-    arguments and keywords are passed to the compiler's configuration
-    functions."""
-
-    return fbuild.builders.c._guess_builder('c++ shared',
-        {'msvc++', 'g++', 'clang++', 'icpc'}, (
-        ({'msvc++'}, 'fbuild.builders.cxx.msvc.shared'),
-        ({'iphone', 'simulator'},
+            'fbuild.builders.cxx.gxx.iphone.static_simulator',
             'fbuild.builders.cxx.gxx.iphone.shared_simulator'),
-        ({'iphone'}, 'fbuild.builders.cxx.gxx.iphone.shared'),
-        ({'darwin', 'clang++'}, 'fbuild.builders.cxx.clangxx.darwin.shared'),
-        ({'darwin'}, 'fbuild.builders.cxx.gxx.darwin.shared'),
-        ({'clang++'}, 'fbuild.builders.cxx.clangxx.shared'),
-        ({'icpc'}, 'fbuild.builders.cxx.intelxx.shared'),
-        ({'g++'}, 'fbuild.builders.cxx.gxx.shared'),
-    ), *args, **kwargs)
+        ({'iphone', 'g++'}, 'fbuild.builders.cxx.gxx.iphone.static',
+                            'fbuild.builders.cxx.gxx.iphone.shared'),
+        ({'darwin', 'clang++'}, 'fbuild.builders.cxx.clangxx.darwin.static',
+                                'fbuild.builders.cxx.clangxx.darwin.shared'),
+        ({'darwin', 'g++'}, 'fbuild.builders.cxx.gxx.darwin.static',
+                            'fbuild.builders.cxx.gxx.darwin.shared'),
+        ({'clang++'}, 'fbuild.builders.cxx.clangxx.static',
+                      'fbuild.builders.cxx.clangxx.shared'),
+        ({'icpc'}, 'fbuild.builders.cxx.intelxx.static',
+                   'fbuild.builders.cxx.intelxx.shared'),
+        ({'g++'}, 'fbuild.builders.cxx.gxx.static',
+                  'fbuild.builders.cxx.gxx.static'),
+    ))
+
+
+@fbuild.builders.c._guess_deprecated
+def guess_static(ctx, **kwargs):
+    return guess.static(ctx, **kwargs)
+
+@fbuild.builders.c._guess_deprecated
+def guess_shared(ctx, **kwargs):
+    return guess.shared(ctx, **kwargs)

--- a/lib/fbuild/builders/platform.py
+++ b/lib/fbuild/builders/platform.py
@@ -181,7 +181,7 @@ def platform_match(platform, matcher):
     required_present = set(p for p in matcher if not p.startswith('!'))
     required_nonpresent = set(p for p in matcher if p.startswith('!'))
 
-    return required_present <= platform and not required_nonpresent <= platform
+    return required_present <= platform and not platform & required_nonpresent
 
 
 def parse_platform_options(ctx, platform, platform_options, kwargs):

--- a/lib/fbuild/config/__init__.py
+++ b/lib/fbuild/config/__init__.py
@@ -30,7 +30,10 @@ class TestMeta(fbuild.db.PersistentMeta):
             return super().__new__(cls, name, bases, attrs)
 
         module = attrs.pop('__module__')
-        new_class = super().__new__(cls, name, bases, {'__module__': module})
+        new_class_attrs = {'__module__': module}
+        if '__classcell__' in attrs:
+            new_class_attrs['__classcell__'] = attrs['__classcell__']
+        new_class = super().__new__(cls, name, bases, new_class_attrs)
         new_class.__field_names__ = []
 
         for parent in parents:

--- a/lib/fbuild/main.py
+++ b/lib/fbuild/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import signal
+import warnings
 
 # Make sure the current working directory is in the search path so we can find
 # the fbuildroot.py.
@@ -86,6 +87,10 @@ def build(ctx):
             raise fbuild.Error('file %r not cached' % ctx.options.delete_file)
         return 0
 
+    # Enable warnings of they aren't forcibly disabled.
+    if not ctx.options.no_warnings:
+        warnings.filterwarnings('always', category=DeprecationWarning)
+
     # We'll use the arguments as our targets.
     targets = ctx.args or ['build']
 
@@ -153,9 +158,8 @@ def main(argv=None):
     # --------------------------------------------------------------------------
 
     # If we don't wrap this in a try...finally block to shutdown the scheduler
-    # after all else finishes, fbuild will hang indefinitely
+    # after all else finishes, fbuild will hang indefinitely.
     try:
-
         # If the fbuildroot doesn't exist, error out. We do this now so that
         # there's a chance to ask fbuild for help first.
         if isinstance(fbuildroot, Exception):

--- a/lib/fbuild/options.py
+++ b/lib/fbuild/options.py
@@ -99,6 +99,10 @@ def make_parser():
             default='pickle',
             help='which database engine to use: (pickle, sqlite, cache). ' \
                  'pickle is the default'),
+        make_option('--no-warnings',
+            action='store_true',
+            default=False,
+            help='suppress warnings for the build script'),
     ])
 
     return parser


### PR DESCRIPTION
Ping @erickt because *this is a big change*...

## Motivation

The current `guess_*` API has some problems:

- There's potential for major ABI mismatches. e.g. if `guess_static` matches GCC 5.0 and `guess_shared` 5.1, any libraries produced by one will be incompatible with the other. This is worse on Windows, where it's not uncommon for GCC to match one and VS to match another (mostly if you accidentally screwed up your flags).
- Code duplication. I'm constantly writing stuff like `kw = {...}; guess_static(**kw); guess_shared(**kw)`. Needing both builders is really a pretty common requirement.

## The new API

It looks kind of like this:

```python
from fbuild.builders.c import guess

def build(ctx):
    # Just a static builder.
    static = guess.static(ctx, exe='gcc', ...)
    # Just a shared builder.
    shared = guess.shared(ctx, exe='gcc', ...)
    # Both builders.
    builders = guess(ctx, static={'exe': 'static options here'}, shared={'exe': 'shared options here'})
    # builders is a Record(static=..., shared=...), so you can do:
    builders.static.build_exe('foo', ['foo.c'])
```

When using `guess(...)`, both builders are guaranteed to be the same compiler. Realistically, this is how it should usually be anyway.

## Other stuff

This brings in a smaller change from the `dev` branch, where Windows != MSVC anymore. Instead, `{'windows'}` just means *this compiler is running on windows*, and `{'msvc', 'msvc++'}` are the actual VS compilers. This should make MinGW work again and simplify a lot of config stuff.

## TODO

- Docs.
- Make sure the Windows changes still work under Windows.